### PR TITLE
docs(readme): clarify runestoneinteractive.com to be an alias of runestone's blog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Runestone Home Page
 ===================
 
 
-This repository contains the source for the homepage at `runestoneinteractive.com <https://runestoneinteractive.com>`_ and `blog.runestone.academy <https://blog.runestone.academy>`_
+This repository contains the source for the homepage at `blog.runestone.academy <https://blog.runestone.academy>`_ (`runestoneinteractive.com <https://runestoneinteractive.com>`_)
 
 If you are interested in authoring a blog post about how you use Runestone in your course, we would welcome your contribution!  You can do it as a PR against this repository or submit the rst as an issue.  And I'll take care of it.
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Runestone Home Page
 ===================
 
 
-This repository contains the source for the homepage at `runestoneinteractive.com <https://blog.runestone.academy>`_ and `blog.runestone.academy <https://blog.runestone.academy>`_
+This repository contains the source for the homepage at `runestoneinteractive.com <https://runestoneinteractive.com>`_ and `blog.runestone.academy <https://blog.runestone.academy>`_
 
 If you are interested in authoring a blog post about how you use Runestone in your course, we would welcome your contribution!  You can do it as a PR against this repository or submit the rst as an issue.  And I'll take care of it.
 


### PR DESCRIPTION
The README is inferred to be two separate websites, when really it is the exact same webpage